### PR TITLE
Add PrimitiveCount to the Logger

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -119,7 +119,7 @@ HRESULT APIENTRY DrawIndexedPrimitive_hook(IDirect3DDevice9* pDevice, D3DPRIMITI
 
 	//logger
 	if ((countStride == Stride || countnumElements == numElements || countmStartregister == mStartregister || countmVectorCount == mVectorCount) ||
-		(countNumVertices == NumVertices / 100) || (countvSize == vSize / 100) || (countpSize == pSize / 100))
+		(countNumVertices == NumVertices / 100) || (countvSize == vSize / 100) || (countpSize == pSize / 100) || (countnumPrimitives == primCount / 100)
 		if (GetAsyncKeyState(VK_END) & 1) //log
 			Log("Stride == %d && NumVertices == %d && vSize == %d && pSize == %d numElements == %d && decl->Type == %d && mStartregister == %d && mVectorCount == %d",
 				Stride, NumVertices, vSize, pSize, numElements, decl->Type, mStartregister, mVectorCount);
@@ -284,6 +284,8 @@ HRESULT APIENTRY EndScene_hook(IDirect3DDevice9* pDevice)
 		ImGui::SliderInt("find pSize", &countpSize, -1, 100);
 		ImGui::SliderInt("find mStartregister", &countmStartregister, -1, 100);
 		ImGui::SliderInt("find mVectorCount", &countmVectorCount, -1, 100);
+		ImGui::SliderInt("find primCount", &countnumPrimitives, -1, 100);
+		
 		//ImGui::Checkbox("Aimbot", &aimbot);
 		//ImGui::SliderInt("Aim Key", &aimkey, 0, 8);
 		//ImGui::SliderInt("Aim Sensitivity", &aimsens, 0, 10);

--- a/main.h
+++ b/main.h
@@ -253,6 +253,7 @@ void SaveCfg()
 	fout << "aimfov " << aimfov << endl;
 	fout << "aimheight " << aimheight << endl;
 	fout << "autoshoot " << autoshoot << endl;
+	fout << "countnumPrimitives" << countnumPrimitives << endl;
 	fout.close();
 }
 
@@ -269,6 +270,7 @@ void LoadCfg()
 	fin >> Word >> aimfov;
 	fin >> Word >> aimheight;
 	fin >> Word >> autoshoot;
+	fin >> Word >> countnumPrimitives;
 	fin.close();
 }
 

--- a/main.h
+++ b/main.h
@@ -83,6 +83,7 @@ int countvSize = -1;
 int countpSize = -1;
 int countmStartregister = -1;
 int countmVectorCount = -1;
+int countnumPrimitives = -1;
 
 LPDIRECT3DTEXTURE9 Red, Green, Blue, Yellow;
 


### PR DESCRIPTION
Hi, in some games the value of PrimitiveCount is really important, for example, in WarZ/ISS.

So, i added this info to the logger, if you want to check models using it's value :) 

I hope it's can help someone.